### PR TITLE
Bunch of fixes for iec60870 stuff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-Eclipse NeoSCADA
-================
+Fork of Eclipse NeoSCADA to maintain iec60870 protocols
+=======================================================
 
-[![Build Status](https://travis-ci.org/eclipse/neoscada.svg?branch=master)](https://travis-ci.org/eclipse/neoscada)
+This is a fork of NeoSCADA. It is otherwise as left by the project,
+except for iec60870 protocol, which we have maintained due to our
+own needs. This is nothing major, just a bunch of small fixes.
+

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data.tests/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/DataChangeModelTest.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data.tests/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/DataChangeModelTest.java
@@ -115,7 +115,7 @@ public class DataChangeModelTest
         this.model.start ();
 
         final MockMirrorCommand mirrorCommand = new MockMirrorCommand ();
-        this.model.writeValue ( new ASDUHeader ( CauseOfTransmission.REQUEST, ASDUAddress.valueOf ( 1 ) ), InformationObjectAddress.valueOf ( 1 ), new CommandValue<Float> ( 1.2f, System.currentTimeMillis () ), (byte)0, mirrorCommand, true );
+        this.model.writeValue ( new ASDUHeader ( CauseOfTransmission.REQUEST, ASDUAddress.valueOf ( 1 ) ), InformationObjectAddress.valueOf ( 1000 ), new CommandValue<Float> ( 1.2f, System.currentTimeMillis () ), (byte)0, mirrorCommand, true );
 
         this.model.stop ().await ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data.tests/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/MockChangeDataModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data.tests/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/MockChangeDataModel.java
@@ -19,6 +19,9 @@ public final class MockChangeDataModel extends ChangeDataModel
         @Override
         public Action prepareWriteValue ( Request<?> request )
         {
+            if (request.getAddress().getAddress() == 1000) // Simulate failure
+                return null;
+
             return () -> CompletableFuture.completedFuture ( null );
         }
     }

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/BufferingChangeModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/model/BufferingChangeModel.java
@@ -74,7 +74,7 @@ public class BufferingChangeModel implements ChangeModel
             this.cache.put ( asduAddress, asduCache );
         }
 
-        if ( asduCache.containsKey ( value ) )
+        if ( asduCache.containsKey ( informationObjectAddress ) )
         {
             // we would overwrite data, flush immediately
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
@@ -97,7 +97,7 @@ public class SineDataModel extends AbstractBaseDataModel
     @Override
     public ListenableFuture<Value<?>> read ( final ASDUAddress asduAddress, final InformationObjectAddress address )
     {
-        if ( ASDU_ADDRESS.equals ( asduAddress.getAddress () ) )
+        if ( ASDU_ADDRESS.equals ( asduAddress ) )
         {
             return null;
         }

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
@@ -74,6 +74,12 @@ public class SineDataModel extends AbstractBaseDataModel
             this.values.add ( new Value<> ( 0.0f, System.currentTimeMillis (), QualityInformation.INVALID ) );
         }
 
+    }
+
+    @Override
+    public synchronized void start() {
+    
+    	super.start();
         this.executor.scheduleAtFixedRate ( new Runnable () {
 
             @Override
@@ -83,7 +89,7 @@ public class SineDataModel extends AbstractBaseDataModel
             }
         }, 0, 250, TimeUnit.MILLISECONDS );
     }
-
+    
     protected synchronized void update ()
     {
         final long tix = System.currentTimeMillis ();

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
@@ -138,16 +138,16 @@ public class SineDataModel extends AbstractBaseDataModel
             @Override
             public Void call () throws Exception
             {
-                return performReadAll ( listener );
+                return performReadAll ( listener, cause );
             }
         } );
     }
 
-    protected synchronized Void performReadAll ( final DataListener listener )
+    protected synchronized Void performReadAll ( final DataListener listener, CauseOfTransmission cause )
     {
         logger.debug ( "performReadAll" );
 
-        listener.dataChangeFloat ( CauseOfTransmission.SPONTANEOUS, ASDU_ADDRESS, this.startAddress, new ArrayList<> ( this.values ) );
+        listener.dataChangeFloat ( cause, ASDU_ADDRESS, this.startAddress, new ArrayList<> ( this.values ) );
 
         logger.debug ( "performReadAll - done" );
         return null;

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.server.data/src/org/eclipse/neoscada/protocol/iec60870/server/data/testing/SineDataModel.java
@@ -198,7 +198,7 @@ public class SineDataModel extends AbstractBaseDataModel
         final MessageBuilder<Float, ?> builder = BUILDER.create ();
         builder.start ( CauseOfTransmission.BACKGROUND, ASDU_ADDRESS );
 
-        while ( builder.addEntry ( new InformationObjectAddress ( this.startAddress.getAddress () + position ), this.values.get ( position ) ) )
+        while ( position < this.size && builder.addEntry ( new InformationObjectAddress ( this.startAddress.getAddress () + position ), this.values.get ( position ) ) )
         {
             position++;
         }

--- a/protocols/org.eclipse.neoscada.protocol.iec60870.tests/src/org/eclipse/neoscada/protocol/iec60870/apci/AckBufferTest.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870.tests/src/org/eclipse/neoscada/protocol/iec60870/apci/AckBufferTest.java
@@ -73,8 +73,8 @@ public class AckBufferTest
     {
         for ( int i = 0; i < 1000; i++ )
         {
-            addMessage ( i % MAX_SEQUENCE, 1 );
-            gotAck ( ( i + 1 ) % MAX_SEQUENCE, 0 );
+            addMessage ( i % (MAX_SEQUENCE+1), 1 );
+            gotAck ( ( i + 1 ) % (MAX_SEQUENCE+1), 0 );
         }
     }
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/ASDUAddressType.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/ASDUAddressType.java
@@ -39,13 +39,13 @@ public enum ASDUAddressType
         @Override
         public int read ( final ByteBuf data )
         {
-            return data.readUnsignedShort ();
+            return data.readUnsignedShortLE ();
         }
 
         @Override
         public void write ( final int address, final ByteBuf out )
         {
-            out.writeShort ( address );
+            out.writeShortLE ( address );
         }
     };
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/InformationObjectAddressType.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/InformationObjectAddressType.java
@@ -33,13 +33,13 @@ public enum InformationObjectAddressType
         @Override
         public int read ( final ByteBuf data )
         {
-            return data.readUnsignedShort ();
+            return data.readUnsignedShortLE ();
         }
 
         @Override
         public void write ( final int address, final ByteBuf out )
         {
-            out.writeShort ( address );
+            out.writeShortLE ( address );
         }
     },
     SIZE_3
@@ -47,13 +47,13 @@ public enum InformationObjectAddressType
         @Override
         public int read ( final ByteBuf data )
         {
-            return data.readUnsignedMedium ();
+            return data.readUnsignedMediumLE ();
         }
 
         @Override
         public void write ( final int address, final ByteBuf out )
         {
-            out.writeMedium ( address );
+            out.writeMediumLE ( address );
         }
     };
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/APDUEncoder.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/APDUEncoder.java
@@ -10,16 +10,14 @@
  *******************************************************************************/
 package org.eclipse.neoscada.protocol.iec60870.apci;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.ReferenceCountUtil;
-
-import java.nio.ByteOrder;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class APDUEncoder extends MessageToByteEncoder<APCIBase>
 {
@@ -54,8 +52,6 @@ public class APDUEncoder extends MessageToByteEncoder<APCIBase>
         final ByteBuf data = msg.getData ();
         try
         {
-            out = out.order ( ByteOrder.LITTLE_ENDIAN );
-
             final int len = data.readableBytes ();
 
             if ( len > Constants.APCI_MAX_DATA_LENGTH )
@@ -66,8 +62,8 @@ public class APDUEncoder extends MessageToByteEncoder<APCIBase>
             out.ensureWritable ( 6 + len );
             out.writeByte ( Constants.START_BYTE );
             out.writeByte ( 4 + len );
-            out.writeShort ( msg.getSendSequenceNumber () << 1 );
-            out.writeShort ( msg.getReceiveSequenceNumber () << 1 );
+            out.writeShortLE ( msg.getSendSequenceNumber () << 1 );
+            out.writeShortLE ( msg.getReceiveSequenceNumber () << 1 );
             out.writeBytes ( data );
         }
         finally
@@ -78,13 +74,11 @@ public class APDUEncoder extends MessageToByteEncoder<APCIBase>
 
     private void handleSFormat ( final Supervisory msg, ByteBuf out )
     {
-        out = out.order ( ByteOrder.LITTLE_ENDIAN );
-
         out.ensureWritable ( 6 );
         out.writeByte ( Constants.START_BYTE );
         out.writeByte ( 4 );
         out.writeBytes ( new byte[] { 0x01, 0x00 } );
-        out.writeShort ( msg.getReceiveSequenceNumber () << 1 );
+        out.writeShortLE ( msg.getReceiveSequenceNumber () << 1 );
     }
 
     private void handleUFormat ( final UnnumberedControl msg, final ByteBuf out )

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/AckBuffer.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/AckBuffer.java
@@ -67,7 +67,10 @@ public class AckBuffer
         }
 
         final int seq = this.sequence;
-        this.sequence = ( this.sequence + 1 ) % this.maxSequence;
+        this.sequence = this.sequence + 1;
+        if (this.sequence > this.maxSequence)
+        	this.sequence = 0;
+        
         final int ack = this.sequence;
 
         if ( this.sequence == 0 )
@@ -100,7 +103,7 @@ public class AckBuffer
     {
         logger.trace ( "Ack - {}", sequenceNumber );
 
-        if ( sequenceNumber % this.maxSequence == this.ackSequence )
+        if ( sequenceNumber == this.ackSequence )
         {
             // duplicate
             return;
@@ -125,7 +128,9 @@ public class AckBuffer
 
         this.buffer[this.ackIndex].clear ();
         this.ackIndex = ( this.ackIndex + 1 ) % this.buffer.length;
-        this.ackSequence = sequenceNumber % this.maxSequence;
+        this.ackSequence = sequenceNumber;
+        if (this.ackSequence > this.maxSequence)
+        	this.ackSequence = 0;
     }
 
     public int getOutstandingAcks ()
@@ -137,7 +142,7 @@ public class AckBuffer
         else
         {
             // we do have a roll over
-            return this.maxSequence - this.ackSequence + this.sequence;
+            return (1 + this.maxSequence) - this.ackSequence + this.sequence;
         }
     }
 }

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/MessageChannel.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/apci/MessageChannel.java
@@ -203,7 +203,12 @@ public class MessageChannel extends ChannelDuplexHandler
 
             incrementReceiveCounter ();
 
-            if ( this.receiveCounter - this.ackSentCounter >= this.options.getAcknowledgeWindow () )
+            int unackedCount = this.receiveCounter - this.ackSentCounter;
+            
+            if (unackedCount < 0)
+            	unackedCount =  unackedCount + (1 + this.options.getMaxSequenceNumber());       	
+            
+            if ( unackedCount >= this.options.getAcknowledgeWindow () )
             {
                 // send S format right now
                 this.timer2.stop (); // just in case the timer was already started

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/Dumper.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/Dumper.java
@@ -143,7 +143,7 @@ public class Dumper
             try
             {
                 boolean changed = false;
-                if ( !field.isAccessible () )
+                if ( !field.canAccess (object) )
                 {
                     changed = true;
                     field.setAccessible ( true );

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/MessageManager.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/MessageManager.java
@@ -10,14 +10,9 @@
  *******************************************************************************/
 package org.eclipse.neoscada.protocol.iec60870.asdu;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
-
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +29,10 @@ import org.eclipse.neoscada.protocol.iec60870.asdu.types.InformationStructure;
 import org.eclipse.neoscada.protocol.iec60870.asdu.types.StandardCause;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 
 public class MessageManager
 {
@@ -172,7 +171,6 @@ public class MessageManager
 
         try
         {
-            buf = buf.order ( ByteOrder.LITTLE_ENDIAN );
             codec.encode ( this.options, msg, buf );
             logger.debug ( "Encoded to {} bytes", buf.writerIndex () );
         }

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandNormalizedValue.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandNormalizedValue.java
@@ -53,7 +53,7 @@ public abstract class AbstractSetPointCommandNormalizedValue extends AbstractInf
 
         this.informationObjectAddress.encode ( options, out );
 
-        out.writeShort ( (short) ( this.value.getValue () * 32768 ) );
+        out.writeShortLE ( (short) ( this.value.getValue () * 32768 ) );
 
         byte b = 0;
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandScaledValue.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandScaledValue.java
@@ -49,7 +49,7 @@ public abstract class AbstractSetPointCommandScaledValue extends AbstractInforma
 
         this.informationObjectAddress.encode ( options, out );
 
-        out.writeShort ( this.value.getValue () );
+        out.writeShortLE ( this.value.getValue () );
 
         byte b = 0;
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandShortFloatingPoint.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/AbstractSetPointCommandShortFloatingPoint.java
@@ -49,7 +49,7 @@ public abstract class AbstractSetPointCommandShortFloatingPoint extends Abstract
 
         this.informationObjectAddress.encode ( options, out );
 
-        out.writeFloat ( this.value.getValue () );
+        out.writeFloatLE ( this.value.getValue () );
 
         byte b = 0;
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandNormalizedValue.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandNormalizedValue.java
@@ -33,7 +33,7 @@ public class SetPointCommandNormalizedValue extends AbstractSetPointCommandNorma
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandNormalizedValueTime.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandNormalizedValueTime.java
@@ -34,7 +34,7 @@ public class SetPointCommandNormalizedValueTime extends AbstractSetPointCommandN
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandScaledValue.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandScaledValue.java
@@ -43,7 +43,7 @@ public class SetPointCommandScaledValue extends AbstractSetPointCommandScaledVal
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandScaledValueTime.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandScaledValueTime.java
@@ -34,7 +34,7 @@ public class SetPointCommandScaledValueTime extends AbstractSetPointCommandScale
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandShortFloatingPoint.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandShortFloatingPoint.java
@@ -43,7 +43,7 @@ public class SetPointCommandShortFloatingPoint extends AbstractSetPointCommandSh
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final float value = data.readFloat ();
+        final float value = data.readFloatLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandShortFloatingPointTime.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/message/SetPointCommandShortFloatingPointTime.java
@@ -34,7 +34,7 @@ public class SetPointCommandShortFloatingPointTime extends AbstractSetPointComma
     {
         final InformationObjectAddress address = InformationObjectAddress.parse ( options, data );
 
-        final float value = data.readFloat ();
+        final float value = data.readFloatLE ();
 
         final byte b = data.readByte ();
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/ASDUAddress.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/ASDUAddress.java
@@ -88,7 +88,7 @@ public class ASDUAddress
     public int[] toArray ()
     {
         final ByteBuf buf = Unpooled.buffer ( 2 );
-        buf.writeShort ( this.address );
+        buf.writeShortLE ( this.address );
         return new int[] { buf.getUnsignedByte ( 0 ), buf.getUnsignedByte ( 1 ) };
     }
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/InformationObjectAddress.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/InformationObjectAddress.java
@@ -104,7 +104,7 @@ public class InformationObjectAddress
     public int[] toArray ()
     {
         final ByteBuf buf = Unpooled.buffer ( 4 );
-        buf.writeMedium ( this.address );
+        buf.writeMediumLE ( this.address );
         return new int[] { buf.getUnsignedByte ( 0 ), buf.getUnsignedByte ( 1 ), buf.getUnsignedByte ( 2 ) };
     }
 

--- a/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/TypeHelper.java
+++ b/protocols/org.eclipse.neoscada.protocol.iec60870/src/org/eclipse/neoscada/protocol/iec60870/asdu/types/TypeHelper.java
@@ -45,7 +45,7 @@ public class TypeHelper
             }
         }
 
-        out.writeShort ( ms );
+        out.writeShortLE ( ms );
         out.writeByte ( minutes ); // we implicitly set "valid"
         out.writeByte ( hourField );
         out.writeByte ( dayOfMonth ); // we implicitly set dayOfWeek to zero here
@@ -55,7 +55,7 @@ public class TypeHelper
 
     public static long parseTimestamp ( final ProtocolOptions options, final ByteBuf data )
     {
-        final int ms = data.readUnsignedShort ();
+        final int ms = data.readUnsignedShortLE ();
 
         int minutes = data.readUnsignedByte ();
         minutes = minutes & 0b00111111; // mask out IV and RES1
@@ -169,7 +169,7 @@ public class TypeHelper
         final byte qds = (byte) ( value.isOverflow () ? 0b00000001 : 0b00000000 );
         final byte siq = value.getQualityInformation ().apply ( qds );
 
-        out.writeFloat ( value.getValue () );
+        out.writeFloatLE ( value.getValue () );
         out.writeByte ( siq );
 
         if ( withTimestamp )
@@ -183,7 +183,7 @@ public class TypeHelper
      */
     public static Value<Float> parseFloatValue ( final ProtocolOptions options, final ByteBuf data, final boolean withTimestamp )
     {
-        final float value = data.readFloat ();
+        final float value = data.readFloatLE ();
 
         final byte qds = data.readByte ();
 
@@ -203,7 +203,7 @@ public class TypeHelper
         final byte qds = (byte) ( value.isOverflow () ? 0b00000001 : 0b00000000 );
         final byte siq = value.getQualityInformation ().apply ( qds );
 
-        out.writeShort ( value.getValue () );
+        out.writeShortLE ( value.getValue () );
         out.writeByte ( siq );
 
         if ( withTimestamp )
@@ -217,7 +217,7 @@ public class TypeHelper
      */
     public static Value<Short> parseScaledValue ( final ProtocolOptions options, final ByteBuf data, final boolean withTimestamp )
     {
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte qds = data.readByte ();
 
@@ -255,7 +255,7 @@ public class TypeHelper
         final byte qds = (byte) ( ( value.isOverflow () || isOverflow ) ? 0b00000001 : 0b00000000 );
         final byte siq = value.getQualityInformation ().apply ( qds );
 
-        out.writeShort ( normalizedValue );
+        out.writeShortLE ( normalizedValue );
         out.writeByte ( siq );
 
         if ( withTimestamp )
@@ -269,7 +269,7 @@ public class TypeHelper
      */
     public static Value<Double> parseNormalizedValue ( final ProtocolOptions options, final ByteBuf data, final boolean withTimestamp )
     {
-        final short value = data.readShort ();
+        final short value = data.readShortLE ();
 
         final byte qds = data.readByte ();
 


### PR DESCRIPTION
This fixes problem with message sequence number wraparound. Original code used comparison with max number in some places and modulus in others, which caused inconsistencies when sequence wrapped from 32767 to 0. Although the system recovered from that, it caused a short communication break because tcp connection was dropped and re-established.

In addition deprecation of Netty ByteBuf.order() is handled by using methods like readIntLE() instead of creating byteorder swapped buffer. This makes code compatible with future Netty versions.

There are also some small fixes like using wrong key to cache hashtable.